### PR TITLE
Replaced invalid ErrorAction parameter value

### DIFF
--- a/neo4j-community-2.2.0/tools/chocolateyInstall.ps1
+++ b/neo4j-community-2.2.0/tools/chocolateyInstall.ps1
@@ -89,7 +89,7 @@ try {
   $existingNeoHome = [string] (Get-EnvironmentVariable -Name 'NEO4J_HOME' -Scope 'Machine')
   if ($existingNeoHome -eq '')
   {
-    $existingNeoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Ignore).'NEO4J_HOME' )
+    $existingNeoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Continue).'NEO4J_HOME' )
   }
   if ($existingNeoHome -ne '') {
     Write-Debug 'The NEO4J_HOME environment variable is set.  Checking the version of Neo4j...'
@@ -147,7 +147,7 @@ try {
     $args = "install"
     Start-Process -FilePath $InstallBatch -ArgumentList $args -Wait -PassThru -NoNewWindow | Out-Null
     
-    $neoService = Get-Service -Name "Neo4j-Server" -ErrorAction Ignore
+    $neoService = Get-Service -Name "Neo4j-Server" -ErrorAction Continue
     if ($neoService -eq $null) {
       Throw "The Neo4j Sever Service failed to install"
     }

--- a/neo4j-community-2.2.0/tools/chocolateyUninstall.ps1
+++ b/neo4j-community-2.2.0/tools/chocolateyUninstall.ps1
@@ -6,7 +6,7 @@ try {
   # Failing that, try a registry hack
   if ($neoHome -eq '')
   {
-    $neoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Ignore).'NEO4J_HOME' )
+    $neoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Continue).'NEO4J_HOME' )
   }
   if ($neoHome -eq '') { throw "Could not find the Neo4jHome directory" }
 


### PR DESCRIPTION
On a fresh machine where Neo4J has never been installed (and has no corresponding registry entries) the installation fails because `Ignore` is passed to the `ErrorAction` parameter when the install script looks for the existing Neo4j home path (and later for the installed service).  The error happens because `Ignore` is not actually defined in the corresponding enum `System.Management.Automation.ActionPreference`.  Valid alternatives with the similar intention are: `Continue` and `SilentlyContinue`.  Here, two occurrences of `Ignore` were replaced with `Continue`.
