### PR TITLE
Add Private JRE download to packages

### DIFF
--- a/automation/Neo4j-Helpers.ps1
+++ b/automation/Neo4j-Helpers.ps1
@@ -59,11 +59,22 @@ Function Invoke-CreateMissingTemplates($RootDir) {
       # Generate the rest of the Package Definition
       $PackageVersion = $neoVersion
       $TemplateName = ''
-      if ($neoVersion -like '3.*') { $TemplateName = 'neo4j-community-v3' }
-      if ($neoVersion -like '2.3.*') { $TemplateName = 'neo4j-community8' }
-      if ($neoVersion -like '2.2.*') { $TemplateName = 'neo4j-community' }
-
+      if ($neoVersion -like '3.*') { $TemplateName = 'neo4j-community-v3.1' }
+      if ($neoVersion -like '2.3.*') { $TemplateName = 'neo4j-community8.1' }
+      # Disabled 2.2 automatic generation as it is no longer developed
+      #if ($neoVersion -like '2.2.*') { $TemplateName = 'neo4j-community' }
       if ($TemplateName -eq '') { Throw "Unable to determine Template Name for Neo4j v$($neoVersion)" }
+
+      # Set Private JRE information
+      if ($neoVersion -like '3.*') {
+        $PrivateJavaVersion = "8.0.92.14"
+        $PrivateJreChecksumMD5 = "a852c7c6195e2ff8d0f0582d4d12a9b0"
+      }
+      if ($neoVersion -like '2.*') {
+        # Neo4j 2.x series is not fully supported in Java 8, but Java 7 is no longer available.
+        $PrivateJavaVersion = "8.0.92.14"
+        $PrivateJreChecksumMD5 = "a852c7c6195e2ff8d0f0582d4d12a9b0"
+      }
 
       # Beta Version
       if ($neoVersion -notmatch ('^[\d\.]+$')) {
@@ -80,6 +91,8 @@ Function Invoke-CreateMissingTemplates($RootDir) {
   "MD5Checksum" = "$($downloadHash.Hash.ToLower())";
   "NeoZipSubdir" = "neo4j-community-$($neoVersion)";
   "NeoServerApiJarSuffix" = "$($neoVersion)";
+  "PrivateJavaVersion" = "$($PrivateJavaVersion)";
+  "PrivateJreChecksumMD5" = "$($PrivateJreChecksumMD5)";
 }
 "@
       $templateFile = Join-Path -Path "$($RootDir)\templates" -ChildPath "package-neo4j-community-$($PackageVersion).ps1"

--- a/default.ps1
+++ b/default.ps1
@@ -30,6 +30,22 @@ Task Pack_All -Depends Clean -Description 'Packs all nuget templates into packag
   Invoke-PackAll
 }
 
+Task Clean_Choco_Install -Description 'Cleans out a failed Neo4j Installation' {
+  # if service delete it
+
+  $installDir = 'C:\tools\neo4j-community'
+  if (Test-Path -Path $installDir) {
+    Write-Host "Purging $installDir ..."
+    Remove-Item -Path $installDir -Recurse -Force -Confirm:$false | Out-Null
+  }
+
+  $installDir = 'C:\ProgramData\chocolatey\lib\neo4j-community'
+  if (Test-Path -Path $installDir) {
+    Write-Host "Purging $installDir ..."
+    Remove-Item -Path $installDir -Recurse -Force -Confirm:$false | Out-Null
+  }
+}
+
 Task Pack -Depends Clean -Description 'Packs a nuget template into a package' {
   if ($pkgName -eq '') { [string]$pkgName = $script:pkgName}
   if ($pkgname -eq '') {

--- a/neo4j-community-2.2.0-M03-beta/README.md
+++ b/neo4j-community-2.2.0-M03-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-2.2.0-M04-beta/README.md
+++ b/neo4j-community-2.2.0-M04-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-2.2.0-RC01-beta/README.md
+++ b/neo4j-community-2.2.0-RC01-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-2.3.0-M01-beta/README.md
+++ b/neo4j-community-2.3.0-M01-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-2.3.0-M02-beta/README.md
+++ b/neo4j-community-2.3.0-M02-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-2.3.7/tools/chocolateyUninstall.ps1
+++ b/neo4j-community-2.3.7/tools/chocolateyUninstall.ps1
@@ -1,4 +1,101 @@
 $PackageName = 'neo4j-community'
+
+Function Get-IsJavaInstalled()
+{
+  [cmdletBinding(SupportsShouldProcess=$false,ConfirmImpact='Low',DefaultParameterSetName='Default')]
+  param (
+    $Neo4jHome
+  )
+  
+  Process
+  {
+    $javaPath = ''
+    $javaVersion = ''
+    $javaCMD = ''
+    
+    $EnvJavaHome = "$($Env:JAVA_HOME)"
+    
+    # Is JAVA specified in an environment variable
+    if (($javaPath -eq '') -and ($EnvJavaHome -ne $null))
+    {
+      $javaPath = $EnvJavaHome
+      # Modify the java path if a JRE install is detected
+      if (Test-Path -Path "$javaPath\bin\javac.exe") { $javaPath = "$javaPath\jre" }
+    }
+
+    # Attempt to find Java in registry
+    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'    
+    if (($javaPath -eq '') -and (Test-Path -Path $regKey))
+    {
+      $javaVersion = ''
+      try
+      {
+        $javaVersion = [string](Get-ItemProperty -Path $regKey -ErrorAction 'Stop').CurrentVersion
+        if ($javaVersion -ne '')
+        {
+          $javaPath = [string](Get-ItemProperty -Path "$regKey\$javaVersion" -ErrorAction 'Stop').JavaHome
+        }
+      }
+      catch
+      {
+        #Ignore any errors
+        $javaVersion = ''
+        $javaPath = ''
+      }
+    }
+
+    # Attempt to find Java in registry (32bit Java on 64bit OS)
+    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'    
+    if (($javaPath -eq '') -and (Test-Path -Path $regKey))
+    {
+      $javaVersion = ''
+      try
+      {
+        $javaVersion = [string](Get-ItemProperty -Path $regKey -ErrorAction 'Stop').CurrentVersion
+        if ($javaVersion -ne '')
+        {
+          $javaPath = [string](Get-ItemProperty -Path "$regKey\$javaVersion" -ErrorAction 'Stop').JavaHome
+        }
+      }
+      catch
+      {
+        #Ignore any errors
+        $javaVersion = ''
+        $javaPath = ''
+      }
+    }
+    
+    # Attempt to find Java in the search path
+    if ($javaPath -eq '')
+    {
+      $javaExe = (Get-Command 'java.exe' -ErrorAction SilentlyContinue)
+      if ($javaExe -ne $null)
+      {
+        $javaCMD = $javaExe.Path
+        $javaPath = Split-Path -Path $javaCMD -Parent
+      }
+    }
+
+    # Attempt to private jre
+    $privateJRE = Join-Path -Path $Neo4jHome -ChildPath 'java'
+    if ( ($javaPath -eq '') -and (Test-Path -Path $privateJRE) )
+    {
+      $privateJRE = (Get-ChildItem -Path "$privateJRE" | Select -First 1).FullName
+
+      if (Test-Path -Path "$privateJRE\bin\java.exe") {
+        $javaCMD = "$privateJRE\bin\java.exe"
+        $javaPath = $privateJRE
+      }
+    }
+
+    if ($javaPath -eq '') { Write-Host "Unable to determine the path to java.exe"; return $false }
+    if ($javaCMD -eq '') { $javaCMD = "$javaPath\bin\java.exe" }
+    if (-not (Test-Path -Path $javaCMD)) { Write-Error "Could not find java at $javaCMD"; return $false }
+ 
+    return $javaPath
+  }
+}
+
 try {
   # Get the NeoHome Dir
   #   Try the local environment
@@ -9,6 +106,11 @@ try {
     $neoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Continue).'NEO4J_HOME' )
   }
   if ($neoHome -eq '') { throw "Could not find the Neo4jHome directory" }
+
+  $javaPath = (Get-IsJavaInstalled -Neo4jHome $neoHome)
+  if ($javaPath -eq '') { throw "Could not find a Java installation" }
+  # Temporarily set the JAVA_HOME environment variable
+  $ENV:JAVA_HOME = $javaPath
 
   # Uninstall the Neo4j Service
   $UninstallBatch = "$($neoHome)\bin\Neo4jInstaller.bat"

--- a/neo4j-community-3.0.0-RC1-beta/README.md
+++ b/neo4j-community-3.0.0-RC1-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-3.0.6/tools/chocolateyInstall.ps1
+++ b/neo4j-community-3.0.6/tools/chocolateyInstall.ps1
@@ -3,6 +3,10 @@ $PackageName = 'neo4j-community'
 $downloadUrl = 'http://neo4j.com/artifact.php?name=neo4j-community-3.0.6-windows.zip'
 $md5Checksum = 'b4473c4b4ad943320b09f28f2703683c'
 $neozipSubdir = 'neo4j-community-3.0.6'
+# major.minor.update.build
+# Build is always 14
+$privateJavaVersion = "8.0.92.14"
+$privateJreChecksumMD5 = "a852c7c6195e2ff8d0f0582d4d12a9b0"
 
 # START Helper Functions
 Function Get-IsJavaInstalled
@@ -79,8 +83,7 @@ Function Get-IsJavaInstalled
       }
     }
 
-    if ($javaVersion -eq '') { Write-Verbose 'Warning: Unable to determine Java version' }
-    if ($javaPath -eq '') { Write-Error "Unable to determine the path to java.exe"; return $false }
+    if ($javaPath -eq '') { Write-Host "Unable to determine the path to java.exe"; return $false }
     if ($javaCMD -eq '') { $javaCMD = "$javaPath\bin\java.exe" }
     if (-not (Test-Path -Path $javaCMD)) { Write-Error "Could not find java at $javaCMD"; return $false }
  
@@ -113,7 +116,54 @@ function Invoke-ModifyConfig($File,$Key,$Value) {
 
   $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding($False)
   [IO.File]::WriteAllText($File,$fileContent,$Utf8NoBomEncoding) | Out-NUll
-}  
+}
+
+function Invoke-InstallPrivateJRE($Destination) {
+  # Adpated from the server-jre8 chocolatey package
+  # https://github.com/rgra/choco-packages/tree/master/server-jre8
+
+  Write-Host "Installing Server JRE $privateJavaVersion to $Destination"
+
+  #8.0.xx to jdk1.8.0_xx
+  $versionArray = $privateJavaVersion.Split(".")
+  $majorVersion = $versionArray[0]
+  $minorVersion = $versionArray[1]
+  $updateVersion = $versionArray[2]
+  $buildNumber = $versionArray[3]
+  $folderVersion = "jdk1.$majorVersion.$($minorVersion)_$updateVersion"
+
+  $fileNameBase = "server-jre-$($majorVersion)u$($updateVersion)-windows-x64"
+  $fileName = "$fileNameBase.tar.gz"
+
+  $url = "http://download.oracle.com/otn-pub/java/jdk/$($majorVersion)u$($updateVersion)-b$buildNumber/$fileName"
+
+  # Download location info
+  $tempDir = Join-Path -Path $ENV:Temp -ChildPath "choco_jre_$PackageName"
+  $tarGzFile = "$tempDir\$fileName"
+  $tarFile = "$tempDir\$fileNameBase.tar"
+
+  # Cleanup
+  if (Test-Path -Path $tempDir) { Remove-Item -Path $tempDir -Force -Recurse -Confirm:$false | Out-Null }
+
+  New-Item -Path $tempDir -ItemType 'Directory' | Out-Null
+
+  $webClient = New-Object System.Net.WebClient
+  $result = $webClient.headers.Add('Cookie','gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie')
+  Write-Host "Downloading $url ..."
+  $result = $webClient.DownloadFile($url, $tarGzFile)
+  Get-ChecksumValid $tarGzFile $privateJreChecksumMD5 | Out-Null
+
+  #Extract gz to .tar File
+  Get-ChocolateyUnzip $tarGzFile $tempDir | Out-Null
+  #Extract tar to destination
+  Get-ChocolateyUnzip $tarFile $Destination | Out-Null
+
+  # Cleanup
+  if (Test-Path -Path $tempDir) { Remove-Item -Path $tempDir -Force -Recurse -Confirm:$false | Out-Null }
+
+  # return the JAVA_HOME path
+  Write-Output (Get-ChildItem -Path $Destination | Select -First 1).FullName
+}
 # END Helper Functions
 
 try {
@@ -217,12 +267,6 @@ try {
     If (!(Test-Path -Path $ImportServiceProperties)) { Throw "Could not find the ServiceProperties file to import. $ImportServiceProperties" }
   }
 
-  # Check if Java is available
-  # This check will not be required once a suitable Java SDK 8 chocolatey package is available in the public feed. This is expected in Feb 2015 sometime.
-  if (-not (Get-IsJavaInstalled) ) {
-    Throw "Could not detect an installation of Java"
-  }
-
   # Install Neo4j
   Install-ChocolateyZipPackage -PackageName $PackageName -URL $downloadUrl -UnzipLocation $InstallDir -CheckSum $md5Checksum -CheckSumType 'md5'
   $neoHome = "$($InstallDir)\$($neozipSubdir)"
@@ -247,6 +291,25 @@ try {
   }
   if ($WindowsServiceName -ne "") {
     Invoke-ModifyConfig -File "$($neoHome)\conf\neo4j-wrapper.conf" -Key "dbms.windows_service_name" -Value $WindowsServiceName | Out-Null
+  }
+
+  # Check if Java is available
+  # This check will not be required once a suitable Java SDK 8 chocolatey package is available in the public feed.
+  if (-not (Get-IsJavaInstalled) ) {
+    Write-Host "Java was not detected.  Installing a private JRE for Neo4j"
+    $privatePath = Invoke-InstallPrivateJRE -Destination "$($neoHome)\java"
+    Write-Host "--------------------"
+    Write-Host "Before using Neo4j tools, ensure you have set the JAVA_HOME"
+    Write-Host "environment variable to $($privatePath)"
+    Write-Host ""
+    Write-Host "For example, in a command prompt:"
+    Write-Host "SET JAVA_HOME=$($privatePath)"
+    Write-Host ""
+    Write-Host "For example, in a PowerShell console:"
+    Write-Host "`$ENV:JAVA_HOME = '$($privatePath)'"
+    Write-Host ""
+    Write-Host "--------------------"
+    $ENV:JAVA_HOME = $privatePath
   }
 
   # Install the Neo4j Service

--- a/neo4j-community-3.0.6/tools/chocolateyUninstall.ps1
+++ b/neo4j-community-3.0.6/tools/chocolateyUninstall.ps1
@@ -1,4 +1,101 @@
 $PackageName = 'neo4j-community'
+
+Function Get-IsJavaInstalled()
+{
+  [cmdletBinding(SupportsShouldProcess=$false,ConfirmImpact='Low',DefaultParameterSetName='Default')]
+  param (
+    $Neo4jHome
+  )
+  
+  Process
+  {
+    $javaPath = ''
+    $javaVersion = ''
+    $javaCMD = ''
+    
+    $EnvJavaHome = "$($Env:JAVA_HOME)"
+    
+    # Is JAVA specified in an environment variable
+    if (($javaPath -eq '') -and ($EnvJavaHome -ne $null))
+    {
+      $javaPath = $EnvJavaHome
+      # Modify the java path if a JRE install is detected
+      if (Test-Path -Path "$javaPath\bin\javac.exe") { $javaPath = "$javaPath\jre" }
+    }
+
+    # Attempt to find Java in registry
+    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'    
+    if (($javaPath -eq '') -and (Test-Path -Path $regKey))
+    {
+      $javaVersion = ''
+      try
+      {
+        $javaVersion = [string](Get-ItemProperty -Path $regKey -ErrorAction 'Stop').CurrentVersion
+        if ($javaVersion -ne '')
+        {
+          $javaPath = [string](Get-ItemProperty -Path "$regKey\$javaVersion" -ErrorAction 'Stop').JavaHome
+        }
+      }
+      catch
+      {
+        #Ignore any errors
+        $javaVersion = ''
+        $javaPath = ''
+      }
+    }
+
+    # Attempt to find Java in registry (32bit Java on 64bit OS)
+    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'    
+    if (($javaPath -eq '') -and (Test-Path -Path $regKey))
+    {
+      $javaVersion = ''
+      try
+      {
+        $javaVersion = [string](Get-ItemProperty -Path $regKey -ErrorAction 'Stop').CurrentVersion
+        if ($javaVersion -ne '')
+        {
+          $javaPath = [string](Get-ItemProperty -Path "$regKey\$javaVersion" -ErrorAction 'Stop').JavaHome
+        }
+      }
+      catch
+      {
+        #Ignore any errors
+        $javaVersion = ''
+        $javaPath = ''
+      }
+    }
+    
+    # Attempt to find Java in the search path
+    if ($javaPath -eq '')
+    {
+      $javaExe = (Get-Command 'java.exe' -ErrorAction SilentlyContinue)
+      if ($javaExe -ne $null)
+      {
+        $javaCMD = $javaExe.Path
+        $javaPath = Split-Path -Path $javaCMD -Parent
+      }
+    }
+
+    # Attempt to private jre
+    $privateJRE = Join-Path -Path $Neo4jHome -ChildPath 'java'
+    if ( ($javaPath -eq '') -and (Test-Path -Path $privateJRE) )
+    {
+      $privateJRE = (Get-ChildItem -Path "$privateJRE" | Select -First 1).FullName
+
+      if (Test-Path -Path "$privateJRE\bin\java.exe") {
+        $javaCMD = "$privateJRE\bin\java.exe"
+        $javaPath = $privateJRE
+      }
+    }
+
+    if ($javaPath -eq '') { Write-Host "Unable to determine the path to java.exe"; return $false }
+    if ($javaCMD -eq '') { $javaCMD = "$javaPath\bin\java.exe" }
+    if (-not (Test-Path -Path $javaCMD)) { Write-Error "Could not find java at $javaCMD"; return $false }
+ 
+    return $javaPath
+  }
+}
+
 try {
   # Get the NeoHome Dir
   #   Try the local environment
@@ -9,6 +106,11 @@ try {
     $neoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Continue).'NEO4J_HOME' )
   }
   if ($neoHome -eq '') { throw "Could not find the Neo4j installation via the NEO4J_HOME environment variable" }
+
+  $javaPath = (Get-IsJavaInstalled -Neo4jHome $neoHome)
+  if ($javaPath -eq '') { throw "Could not find a Java installation" }
+  # Temporarily set the JAVA_HOME environment variable
+  $ENV:JAVA_HOME = $javaPath
 
   # Uninstall the Neo4j Service
   $UninstallBatch = "$($neoHome)\bin\Neo4j.bat"

--- a/neo4j-community-3.1.0-M07-beta/README.md
+++ b/neo4j-community-3.1.0-M07-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-3.1.0-M08-beta/README.md
+++ b/neo4j-community-3.1.0-M08-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-3.1.0-M09-beta/PackageTemplate.nuspec
+++ b/neo4j-community-3.1.0-M09-beta/PackageTemplate.nuspec
@@ -18,7 +18,7 @@
     <description><![CDATA[ Neo4j is the world's leading Graph Database. It is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions. The programmer works with a flexible network structure of nodes and relationships rather than static tables yet enjoys all the benefits of enterprise-quality database. For many applications, Neo4j offers orders of magnitude performance benefits compared to relational DBs.
 
 Note - This chocolatey package is not created or maintained by Neo4j, however the installation media used is an official distribution from Neo4j
-* Requires OpenJDK 7/8 or Oracle Java 7/8 to be installed as per http://neo4j.com/docs/stable/deployment-requirements.html#_software
+* Requires OpenJDK 8 or Oracle Java 8 to be installed as per http://neo4j.com/docs/stable/deployment-requirements.html#_software
 * This package only installs the 64 bit version
 * This chocolatey package supports Package Parameters;
 `/Install:[Install Path]`

--- a/neo4j-community-3.1.0-M09-beta/README.md
+++ b/neo4j-community-3.1.0-M09-beta/README.md
@@ -4,7 +4,7 @@ neo4j-community
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/neo4j-community-3.1.0-M09-beta/README.md
+++ b/neo4j-community-3.1.0-M09-beta/README.md
@@ -12,7 +12,7 @@ http://neo4j.com/
 
 ## How do I install it?
 1. Install Chocolatey https://chocolatey.org/
-2. Install OpenJDK 7 or Oracle Java 7 http://neo4j.com/docs/stable/deployment-requirements.html#_software
+2. Install OpenJDK 8 or Oracle Java 8 http://neo4j.com/docs/stable/deployment-requirements.html#_software
 3. Install this package.  This package requried the -prelease flag
 ```powershell
 choco install neo4j-community -version 3.1.0-M09-beta -prerelease

--- a/neo4j-community-3.1.0-M09-beta/tools/chocolateyUninstall.ps1
+++ b/neo4j-community-3.1.0-M09-beta/tools/chocolateyUninstall.ps1
@@ -1,4 +1,101 @@
 $PackageName = 'neo4j-community'
+
+Function Get-IsJavaInstalled()
+{
+  [cmdletBinding(SupportsShouldProcess=$false,ConfirmImpact='Low',DefaultParameterSetName='Default')]
+  param (
+    $Neo4jHome
+  )
+  
+  Process
+  {
+    $javaPath = ''
+    $javaVersion = ''
+    $javaCMD = ''
+    
+    $EnvJavaHome = "$($Env:JAVA_HOME)"
+    
+    # Is JAVA specified in an environment variable
+    if (($javaPath -eq '') -and ($EnvJavaHome -ne $null))
+    {
+      $javaPath = $EnvJavaHome
+      # Modify the java path if a JRE install is detected
+      if (Test-Path -Path "$javaPath\bin\javac.exe") { $javaPath = "$javaPath\jre" }
+    }
+
+    # Attempt to find Java in registry
+    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'    
+    if (($javaPath -eq '') -and (Test-Path -Path $regKey))
+    {
+      $javaVersion = ''
+      try
+      {
+        $javaVersion = [string](Get-ItemProperty -Path $regKey -ErrorAction 'Stop').CurrentVersion
+        if ($javaVersion -ne '')
+        {
+          $javaPath = [string](Get-ItemProperty -Path "$regKey\$javaVersion" -ErrorAction 'Stop').JavaHome
+        }
+      }
+      catch
+      {
+        #Ignore any errors
+        $javaVersion = ''
+        $javaPath = ''
+      }
+    }
+
+    # Attempt to find Java in registry (32bit Java on 64bit OS)
+    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'    
+    if (($javaPath -eq '') -and (Test-Path -Path $regKey))
+    {
+      $javaVersion = ''
+      try
+      {
+        $javaVersion = [string](Get-ItemProperty -Path $regKey -ErrorAction 'Stop').CurrentVersion
+        if ($javaVersion -ne '')
+        {
+          $javaPath = [string](Get-ItemProperty -Path "$regKey\$javaVersion" -ErrorAction 'Stop').JavaHome
+        }
+      }
+      catch
+      {
+        #Ignore any errors
+        $javaVersion = ''
+        $javaPath = ''
+      }
+    }
+    
+    # Attempt to find Java in the search path
+    if ($javaPath -eq '')
+    {
+      $javaExe = (Get-Command 'java.exe' -ErrorAction SilentlyContinue)
+      if ($javaExe -ne $null)
+      {
+        $javaCMD = $javaExe.Path
+        $javaPath = Split-Path -Path $javaCMD -Parent
+      }
+    }
+
+    # Attempt to private jre
+    $privateJRE = Join-Path -Path $Neo4jHome -ChildPath 'java'
+    if ( ($javaPath -eq '') -and (Test-Path -Path $privateJRE) )
+    {
+      $privateJRE = (Get-ChildItem -Path "$privateJRE" | Select -First 1).FullName
+
+      if (Test-Path -Path "$privateJRE\bin\java.exe") {
+        $javaCMD = "$privateJRE\bin\java.exe"
+        $javaPath = $privateJRE
+      }
+    }
+
+    if ($javaPath -eq '') { Write-Host "Unable to determine the path to java.exe"; return $false }
+    if ($javaCMD -eq '') { $javaCMD = "$javaPath\bin\java.exe" }
+    if (-not (Test-Path -Path $javaCMD)) { Write-Error "Could not find java at $javaCMD"; return $false }
+ 
+    return $javaPath
+  }
+}
+
 try {
   # Get the NeoHome Dir
   #   Try the local environment
@@ -9,6 +106,11 @@ try {
     $neoHome = [string] ( (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -ErrorAction Continue).'NEO4J_HOME' )
   }
   if ($neoHome -eq '') { throw "Could not find the Neo4j installation via the NEO4J_HOME environment variable" }
+
+  $javaPath = (Get-IsJavaInstalled -Neo4jHome $neoHome)
+  if ($javaPath -eq '') { throw "Could not find a Java installation" }
+  # Temporarily set the JAVA_HOME environment variable
+  $ENV:JAVA_HOME = $javaPath
 
   # Uninstall the Neo4j Service
   $UninstallBatch = "$($neoHome)\bin\Neo4j.bat"

--- a/templates/neo4j-community-beta/README.md
+++ b/templates/neo4j-community-beta/README.md
@@ -4,7 +4,7 @@
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/templates/neo4j-community-beta8/README.md
+++ b/templates/neo4j-community-beta8/README.md
@@ -4,7 +4,7 @@
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/templates/neo4j-community-v3-beta/README.md
+++ b/templates/neo4j-community-v3-beta/README.md
@@ -4,7 +4,7 @@
 ## What is this?
 This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
 
-The chocolate package can be found at https://chocolatey.org/packages/neo4j-community-beta
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
 
 https://chocolatey.org
 

--- a/templates/neo4j-community-v3.1-beta/PackageTemplate.nuspec
+++ b/templates/neo4j-community-v3.1-beta/PackageTemplate.nuspec
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>{{PackageName}}</id>
+    <version>{{PackageVersion}}</version>
+    <title>Neo4j Community Edition</title>
+    <authors>Emil Eifrem,Johan Svensson</authors><!-- App Owners -->
+    <owners>Glenn Sarti</owners> <!-- Package Maintainers -->
+    <licenseUrl>http://neo4j.com/open-source-project/</licenseUrl>
+    <projectUrl>http://neo4j.com/</projectUrl>
+    <projectSourceUrl>https://github.com/neo4j/neo4j</projectSourceUrl>
+    <docsUrl>http://neo4j.com/docs/</docsUrl>
+    <mailingListUrl>https://support.neo4j.com</mailingListUrl>
+    <bugTrackerUrl>https://github.com/neo4j/neo4j/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/glennsarti/neo4j-community-chocolatey</packageSourceUrl>
+    <iconUrl><![CDATA[ https://avatars3.githubusercontent.com/u/201120?v=3&s=200 ]]></iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description><![CDATA[ Neo4j is the world's leading Graph Database. It is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions. The programmer works with a flexible network structure of nodes and relationships rather than static tables yet enjoys all the benefits of enterprise-quality database. For many applications, Neo4j offers orders of magnitude performance benefits compared to relational DBs.
+
+Note - This chocolatey package is not created or maintained by Neo4j, however the installation media used is an official distribution from Neo4j
+* Requires OpenJDK 8 or Oracle Java 8 to be installed as per http://neo4j.com/docs/stable/deployment-requirements.html#_software
+* This package only installs the 64 bit version
+* This chocolatey package supports Package Parameters;
+`/Install:[Install Path]`
+`/ImportNeoProperties:[Path to file]`
+`/ImportServiceProperties:[Path to file]`
+`/HTTPEndPoint:[Host/IP:port]`
+`/HTTPSEndPoint:[Host/IP:port]`
+`/ServiceName:[Windows Service Name]`
+
+### This will install BETA software and is for development only
+
+e.g. `choco install {{PackageName}} -version {{PackageVersion}} -prerelease -packageParameters "/Install:C:\Apps\Neo"`
+
+Full information is available at the pacakge project site https://github.com/glennsarti/neo4j-community-chocolatey
+    ]]></description>
+    <summary>Neo4j is a high performance graph store.  It is scalable, highly-performant and open source.</summary>
+    <releaseNotes>Full list of changes are available on GitHub; https://github.com/glennsarti/neo4j-community-chocolatey
+
+### Version {{PackageVersion}}
+* Initial Release
+    </releaseNotes>
+    <tags>neo4j graph community database nosql admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/templates/neo4j-community-v3.1-beta/README.md
+++ b/templates/neo4j-community-v3.1-beta/README.md
@@ -1,0 +1,65 @@
+{{PackageName}}
+==========================
+
+## What is this?
+This project is a Chocolatey package to install the **Beta** Neo4j Community Edition onto a Windows based computer.
+
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
+
+https://chocolatey.org
+
+http://neo4j.com/
+
+## How do I install it?
+1. Install Chocolatey https://chocolatey.org/
+2. Install OpenJDK 8 or Oracle Java 8 http://neo4j.com/docs/stable/deployment-requirements.html#_software
+3. Install this package.  This package requried the -prelease flag
+```powershell
+choco install {{PackageName}} -version {{PackageVersion}} -prerelease
+```
+4. Open a browser to http://localhost:7474
+
+## What package parameters can I use?
+The package supports the following parameters;
+
+```
+/Install:<Install Path>
+```
+Installs Neo4j to the specified directory.  The default is to install to `<Chocolatey Bin Root>\{{PackageName}}` which is typically `C:\tools\Neo4jCommunity`
+
+```
+/ImportNeoProperties:<Path to file>
+```
+Copies the file specified to `<Install Path>\conf\neo4j.conf`.  This is a quick way to configure the Neo4j server prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-configuration.html
+
+```
+/ImportServiceProperties:<Path to file>
+```
+Copies the file specified to `<Install Path>\conf\neo4j-wrapper.conf`.  This is a quick way to configure the Neo4j Windows Service prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-performance.html
+
+```
+/WindowsServiceName:<Name of Windows Service>
+```
+The name of the windows service which will be installed.
+
+Note - This setting overrides the ServiceProperties file
+
+```
+/HTTPEndpoint:<IP Address or hostname>:<Port>
+```
+The HTTP Endpoint that will be used by the Neo4j server e.g. localhost:7474
+
+Note - This setting overrides the NeoProperties file
+
+```
+/HTTPSEndpoint:<IP Address or hostname>:<Port>
+```
+The HTTPS Endpoint that will be used by the Neo4j server e.g. 0.0.0.0:7473
+
+Note - This setting overrides the NeoProperties file
+
+Example usage;
+``` powershell
+choco install {{PackageName}} -version {{PackageVersion}} -prerelease -packageParameters "/Install:C:\Apps\Neo /ImportNeoProperties:C:\Config\MyNeoProperites.txt /ImportNeoServerProperties:C:\Config\MyNeoServerProperites.txt"
+```
+This command will install Neo4j to `C:\Apps\Neo`, import the *neo4j.properties* file from `C:\Config\MyNeoProperites.txt` and the *neo4j-server.properties* file from `C:\Config\MyNeoServerProperites.txt`

--- a/templates/neo4j-community-v3.1-beta/tools/chocolateyInstall.ps1
+++ b/templates/neo4j-community-v3.1-beta/tools/chocolateyInstall.ps1
@@ -1,12 +1,12 @@
-$PackageName = 'neo4j-community'
+$PackageName = '{{PackageName}}'
 # Per-package parameters
-$downloadUrl = 'http://neo4j.com/artifact.php?name=neo4j-community-3.0.5-windows.zip'
-$md5Checksum = '9b0cf52efcb7f65242490f26beb530c3'
-$neozipSubdir = 'neo4j-community-3.0.5'
+$downloadUrl = '{{DownloadURL}}'
+$md5Checksum = '{{MD5Checksum}}'
+$neozipSubdir = '{{NeoZipSubdir}}'
 # major.minor.update.build
 # Build is always 14
-$privateJavaVersion = "8.0.92.14"
-$privateJreChecksumMD5 = "a852c7c6195e2ff8d0f0582d4d12a9b0"
+$privateJavaVersion = "{{PrivateJavaVersion}}"
+$privateJreChecksumMD5 = "{{PrivateJreChecksumMD5}}"
 
 # START Helper Functions
 Function Get-IsJavaInstalled
@@ -294,7 +294,7 @@ try {
   }
 
   # Check if Java is available
-  # This check will not be required once a suitable Java SDK 8 chocolatey package is available in the public feed.
+  # This check will not be required once a suitable Java SDK 8 chocolatey package is available in the public feed. This is expected in Feb 2015 sometime.
   if (-not (Get-IsJavaInstalled) ) {
     Write-Host "Java was not detected.  Installing a private JRE for Neo4j"
     $privatePath = Invoke-InstallPrivateJRE -Destination "$($neoHome)\java"

--- a/templates/neo4j-community-v3.1-beta/tools/chocolateyUninstall.ps1
+++ b/templates/neo4j-community-v3.1-beta/tools/chocolateyUninstall.ps1
@@ -1,4 +1,4 @@
-$PackageName = 'neo4j-community'
+$PackageName = '{{PackageName}}'
 
 Function Get-IsJavaInstalled()
 {

--- a/templates/neo4j-community-v3.1/PackageTemplate.nuspec
+++ b/templates/neo4j-community-v3.1/PackageTemplate.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>{{PackageName}}</id>
+    <version>{{PackageVersion}}</version>
+    <title>Neo4j Community Edition</title>
+    <authors>Emil Eifrem,Johan Svensson</authors><!-- App Owners -->
+    <owners>Glenn Sarti</owners> <!-- Package Maintainers -->
+    <licenseUrl>http://neo4j.com/open-source-project/</licenseUrl>
+    <projectUrl>http://neo4j.com/</projectUrl>
+    <projectSourceUrl>https://github.com/neo4j/neo4j</projectSourceUrl>
+    <docsUrl>http://neo4j.com/docs/</docsUrl>
+    <mailingListUrl>https://support.neo4j.com</mailingListUrl>
+    <bugTrackerUrl>https://github.com/neo4j/neo4j/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/glennsarti/neo4j-community-chocolatey</packageSourceUrl>
+    <iconUrl><![CDATA[ https://avatars3.githubusercontent.com/u/201120?v=3&s=200 ]]></iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description><![CDATA[ Neo4j is the world's leading Graph Database. It is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions. The programmer works with a flexible network structure of nodes and relationships rather than static tables yet enjoys all the benefits of enterprise-quality database. For many applications, Neo4j offers orders of magnitude performance benefits compared to relational DBs.
+
+Note - This chocolatey package is not created or maintained by Neo4j, however the installation media used is an official distribution from Neo4j
+* Requires OpenJDK 8 or Oracle Java 8 to be installed as per http://neo4j.com/docs/stable/deployment-requirements.html#_software
+* This package only installs the 64 bit version
+* This chocolatey package supports Package Parameters;
+`/Install:[Install Path]`
+`/ImportNeoProperties:[Path to file]`
+`/ImportServiceProperties:[Path to file]`
+`/HTTPEndPoint:[Host/IP:port]`
+`/HTTPSEndPoint:[Host/IP:port]`
+`/ServiceName:[Windows Service Name]`
+
+e.g. `choco install {{PackageName}} -version {{PackageVersion}} -packageParameters "/Install:C:\Apps\Neo"`
+
+Full information is available at the pacakge project site https://github.com/glennsarti/neo4j-community-chocolatey
+    ]]></description>
+    <summary>Neo4j is a high performance graph store.  It is scalable, highly-performant and open source.</summary>
+    <releaseNotes>Full list of changes are available on GitHub; https://github.com/glennsarti/neo4j-community-chocolatey
+
+### Version {{PackageVersion}}
+* Initial Release
+    </releaseNotes>
+    <tags>neo4j graph community database nosql admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/templates/neo4j-community-v3.1/README.md
+++ b/templates/neo4j-community-v3.1/README.md
@@ -1,0 +1,65 @@
+{{PackageName}}
+==========================
+
+## What is this?
+This project is a Chocolatey package to install the Neo4j Community Edition onto a Windows based computer.
+
+The chocolate package can be found at https://chocolatey.org/packages/neo4j-community
+
+https://chocolatey.org
+
+http://neo4j.com/
+
+## How do I install it?
+1. Install Chocolatey https://chocolatey.org/
+2. Install OpenJDK 8 or Oracle Java 8 http://neo4j.com/docs/stable/deployment-requirements.html#_software
+3. Install this package.  This package requried the -prelease flag
+```powershell
+choco install {{PackageName}} -version {{PackageVersion}}
+```
+4. Open a browser to http://localhost:7474
+
+## What package parameters can I use?
+The package supports the following parameters;
+
+```
+/Install:<Install Path>
+```
+Installs Neo4j to the specified directory.  The default is to install to `<Chocolatey Bin Root>\{{PackageName}}` which is typically `C:\tools\Neo4jCommunity`
+
+```
+/ImportNeoProperties:<Path to file>
+```
+Copies the file specified to `<Install Path>\conf\neo4j.conf`.  This is a quick way to configure the Neo4j server prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-configuration.html
+
+```
+/ImportServiceProperties:<Path to file>
+```
+Copies the file specified to `<Install Path>\conf\neo4j-wrapper.conf`.  This is a quick way to configure the Neo4j Windows Service prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-performance.html
+
+```
+/WindowsServiceName:<Name of Windows Service>
+```
+The name of the windows service which will be installed.
+
+Note - This setting overrides the ServiceProperties file
+
+```
+/HTTPEndpoint:<IP Address or hostname>:<Port>
+```
+The HTTP Endpoint that will be used by the Neo4j server e.g. localhost:7474
+
+Note - This setting overrides the NeoProperties file
+
+```
+/HTTPSEndpoint:<IP Address or hostname>:<Port>
+```
+The HTTPS Endpoint that will be used by the Neo4j server e.g. 0.0.0.0:7473
+
+Note - This setting overrides the NeoProperties file
+
+Example usage;
+``` powershell
+choco install {{PackageName}} -version {{PackageVersion}} -packageParameters "/Install:C:\Apps\Neo /ImportNeoProperties:C:\Config\MyNeoProperites.txt /ImportNeoServerProperties:C:\Config\MyNeoServerProperites.txt"
+```
+This command will install Neo4j to `C:\Apps\Neo`, import the *neo4j.properties* file from `C:\Config\MyNeoProperites.txt` and the *neo4j-server.properties* file from `C:\Config\MyNeoServerProperites.txt`

--- a/templates/neo4j-community-v3.1/tools/chocolateyInstall.ps1
+++ b/templates/neo4j-community-v3.1/tools/chocolateyInstall.ps1
@@ -1,12 +1,12 @@
-$PackageName = 'neo4j-community'
+$PackageName = '{{PackageName}}'
 # Per-package parameters
-$downloadUrl = 'http://neo4j.com/artifact.php?name=neo4j-community-3.0.5-windows.zip'
-$md5Checksum = '9b0cf52efcb7f65242490f26beb530c3'
-$neozipSubdir = 'neo4j-community-3.0.5'
+$downloadUrl = '{{DownloadURL}}'
+$md5Checksum = '{{MD5Checksum}}'
+$neozipSubdir = '{{NeoZipSubdir}}'
 # major.minor.update.build
 # Build is always 14
-$privateJavaVersion = "8.0.92.14"
-$privateJreChecksumMD5 = "a852c7c6195e2ff8d0f0582d4d12a9b0"
+$privateJavaVersion = "{{PrivateJavaVersion}}"
+$privateJreChecksumMD5 = "{{PrivateJreChecksumMD5}}"
 
 # START Helper Functions
 Function Get-IsJavaInstalled

--- a/templates/neo4j-community-v3.1/tools/chocolateyUninstall.ps1
+++ b/templates/neo4j-community-v3.1/tools/chocolateyUninstall.ps1
@@ -1,4 +1,4 @@
-$PackageName = 'neo4j-community'
+$PackageName = '{{PackageName}}'
 
 Function Get-IsJavaInstalled()
 {

--- a/templates/neo4j-community8.1/PackageTemplate.nuspec
+++ b/templates/neo4j-community8.1/PackageTemplate.nuspec
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>{{PackageName}}</id>
+    <version>{{PackageVersion}}</version>
+    <title>Neo4j Community Edition</title>
+    <authors>Emil Eifrem,Johan Svensson</authors><!-- App Owners -->
+    <owners>Glenn Sarti</owners> <!-- Package Maintainers -->
+    <licenseUrl>http://neo4j.com/open-source-project/</licenseUrl>
+    <projectUrl>http://neo4j.com/</projectUrl>
+    <projectSourceUrl>https://github.com/neo4j/neo4j</projectSourceUrl>
+    <docsUrl>http://neo4j.com/docs/</docsUrl>
+    <mailingListUrl>https://support.neo4j.com</mailingListUrl>
+    <bugTrackerUrl>https://github.com/neo4j/neo4j/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/glennsarti/neo4j-community-chocolatey</packageSourceUrl>
+    <iconUrl><![CDATA[ https://avatars3.githubusercontent.com/u/201120?v=3&s=200 ]]></iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description><![CDATA[ Neo4j is the world's leading Graph Database. It is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions. The programmer works with a flexible network structure of nodes and relationships rather than static tables yet enjoys all the benefits of enterprise-quality database. For many applications, Neo4j offers orders of magnitude performance benefits compared to relational DBs.
+
+Note - This chocolatey package is not created or maintained by Neo4j, however the installation media used is an official distribution from Neo4j
+* Requires OpenJDK 8 or Oracle Java 8 to be installed as per http://neo4j.com/docs/stable/deployment-requirements.html#_software
+* This package only installs the 64 bit version
+* This chocolatey package supports Package Parameters;  
+`/Install:<Install Path>`
+`/ImportNeoProperties:<Path to file>`
+`/ImportNeoServerProperties:<Path to file>`
+`/ImportServiceProperties:<Path to file>`
+
+e.g. `choco install {{PackageName}} -version {{PackageVersion}} -packageParameters "/Install:C:\Apps\Neo"`
+
+Full information is available at the pacakge project site https://github.com/glennsarti/neo4j-community-chocolatey    
+    ]]></description>
+    <summary>Neo4j is a high performance graph store.  It is scalable, highly-performant and open source.</summary>
+    <releaseNotes>Full list of changes are available on GitHub; https://github.com/glennsarti/neo4j-community-chocolatey
+
+### Version {{PackageVersion}}
+* Initial Release
+    </releaseNotes>
+    <tags>neo4j graph community database nosql admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/templates/neo4j-community8.1/README.md
+++ b/templates/neo4j-community8.1/README.md
@@ -1,0 +1,49 @@
+{{PackageName}}
+==========================
+
+## What is this?
+This project is a Chocolatey package to install Neo4j Community Edition onto a Windows based computer.
+
+The chocolate package can be found at https://chocolatey.org/packages/{{PackageName}}
+
+https://chocolatey.org
+
+http://neo4j.com/
+
+## How do I install it?
+1. Install Chocolatey https://chocolatey.org/
+2. Install OpenJDK 8 or Oracle Java 8 http://neo4j.com/docs/stable/deployment-requirements.html#_software
+3. Install this package
+```powershell
+choco install {{PackageName}} -version {{PackageVersion}}
+```
+4. Open a browser to http://localhost:7474
+
+## What package parameters can I use?
+The package supports the following parameters;
+
+```
+/Install:<Install Path>
+```
+Installs Neo4j to the specified directory.  The default is to install to `<Chocolatey Bin Root>\Neo4jCommunity` which is typically `C:\tools\Neo4jCommunity`
+
+```
+/ImportNeoProperties:<Path to file>
+```
+Copies the file specified to `%NEO4J_HOME%\conf\neo4j.properties`.  This is a quick way to configure the Neo4j server prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-configuration.html
+
+```
+/ImportNeoServerProperties:<Path to file>
+```
+Copies the file specified to `%NEO4J_HOME%\conf\neo4j-server.properties`.  This is a quick way to configure the Neo4j server prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-performance.html
+
+```
+/ImportServiceProperties:<Path to file>
+```
+Copies the file specified to `%NEO4J_HOME%\conf\neo4j-wrapper.conf`.  This is a quick way to configure the Neo4j Windows Service prior to service start.  Information about the configuration file can be found at http://neo4j.com/docs/stable/server-performance.html
+
+Example usage;
+```powershell
+choco install {{PackageName}} -version {{PackageVersion}} -packageParameters "/Install:C:\Apps\Neo /ImportNeoProperties:C:\Config\MyNeoProperites.txt /ImportNeoServerProperties:C:\Config\MyNeoServerProperites.txt"
+```
+This command will install Neo4j to `C:\Apps\Neo`, import the *neo4j.properties* file from `C:\Config\MyNeoProperites.txt` and the *neo4j-server.properties* file from `C:\Config\MyNeoServerProperites.txt`

--- a/templates/package-neo4j-community-2.3.7.ps1
+++ b/templates/package-neo4j-community-2.3.7.ps1
@@ -1,9 +1,11 @@
 $PackageDefinition = @{
-  "TemplateName" = "neo4j-community8";
+  "TemplateName" = "neo4j-community8.1";
   "PackageName" = "neo4j-community";
   "PackageVersion" = "2.3.7";
   "DownloadURL" = "http://neo4j.com/artifact.php?name=neo4j-community-2.3.7-windows.zip";
   "MD5Checksum" = "ac1200a9c15ee9b9798e9bdc07c92f63";
   "NeoZipSubdir" = "neo4j-community-2.3.7";
   "NeoServerApiJarSuffix" = "2.3.7";
+  "PrivateJavaVersion" = "8.0.92.14";
+  "PrivateJreChecksumMD5" = "a852c7c6195e2ff8d0f0582d4d12a9b0";
 }

--- a/templates/package-neo4j-community-3.0.5.ps1
+++ b/templates/package-neo4j-community-3.0.5.ps1
@@ -1,9 +1,11 @@
 $PackageDefinition = @{
-  "TemplateName" = "neo4j-community-v3";
+  "TemplateName" = "neo4j-community-v3.1";
   "PackageName" = "neo4j-community";
   "PackageVersion" = "3.0.5";
   "DownloadURL" = "http://neo4j.com/artifact.php?name=neo4j-community-3.0.5-windows.zip";
   "MD5Checksum" = "9b0cf52efcb7f65242490f26beb530c3";
   "NeoZipSubdir" = "neo4j-community-3.0.5";
   "NeoServerApiJarSuffix" = "3.0.5";
+  "PrivateJavaVersion" = "8.0.92.14";
+  "PrivateJreChecksumMD5" = "a852c7c6195e2ff8d0f0582d4d12a9b0";
 }

--- a/templates/package-neo4j-community-3.0.6.ps1
+++ b/templates/package-neo4j-community-3.0.6.ps1
@@ -1,9 +1,11 @@
 $PackageDefinition = @{
-  "TemplateName" = "neo4j-community-v3";
+  "TemplateName" = "neo4j-community-v3.1";
   "PackageName" = "neo4j-community";
   "PackageVersion" = "3.0.6";
   "DownloadURL" = "http://neo4j.com/artifact.php?name=neo4j-community-3.0.6-windows.zip";
   "MD5Checksum" = "b4473c4b4ad943320b09f28f2703683c";
   "NeoZipSubdir" = "neo4j-community-3.0.6";
   "NeoServerApiJarSuffix" = "3.0.6";
+  "PrivateJavaVersion" = "8.0.92.14";
+  "PrivateJreChecksumMD5" = "a852c7c6195e2ff8d0f0582d4d12a9b0";
 }

--- a/templates/package-neo4j-community-3.1.0-M09-beta.ps1
+++ b/templates/package-neo4j-community-3.1.0-M09-beta.ps1
@@ -1,9 +1,11 @@
 $PackageDefinition = @{
-  "TemplateName" = "neo4j-community-v3-beta";
+  "TemplateName" = "neo4j-community-v3.1-beta";
   "PackageName" = "neo4j-community";
   "PackageVersion" = "3.1.0-M09-beta";
   "DownloadURL" = "http://neo4j.com/artifact.php?name=neo4j-community-3.1.0-M09-windows.zip";
   "MD5Checksum" = "096563f42c83dd5dc8776b035d85a838";
   "NeoZipSubdir" = "neo4j-community-3.1.0-M09";
   "NeoServerApiJarSuffix" = "3.1.0-M09";
+  "PrivateJavaVersion" = "8.0.92.14";
+  "PrivateJreChecksumMD5" = "a852c7c6195e2ff8d0f0582d4d12a9b0";
 }


### PR DESCRIPTION
This PR will add a private JRE if JAVA is not found on the host computer
- [x] Create Neo4j v3.x template to install JRE 8
- [x] Add private jre the java search location for uninstall
- [x] Create Neo4j v3.x BETA template to install JRE 8
- [x] Move JRE properties to package template properties instead of in chocolateyInstall
- [x] Create Neo4j v2.x template to install JRE 8
- [x] Create Neo4j v2.x BETA template to install JRE 8
- [x] Update Neo4j 3.0.6
- [x] Update Neo4j 3.0.5
- [x] Update Neo4j 2.3.7
- [x] Update Neo4j 3.1.0-M09
- [x] Upload new packages to Chocolatey.org
- [x] Updated auto package discovery script for new package templates
